### PR TITLE
#34 Point THE SOURCE to github/MetaFam instead of SourceCred

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -32,7 +32,7 @@ const Footer = () => (
     </TextLink>
     <TextLink
       styleProps={{ fontSize: '0.75rem' }}
-      href="https://metafam.github.io/TheSource/timeline/@metagame/">
+      href="https://github.com/MetaFam">
       🧬 THE SOURCE
     </TextLink>
     


### PR DESCRIPTION
Updated the link to point to the main MetaFam github from where users can navigate to whichever sub-project they'd like to contribute to